### PR TITLE
fix upper-case import to prevent errors on linux

### DIFF
--- a/src/twotint/sprites/SpriteH.ts
+++ b/src/twotint/sprites/SpriteH.ts
@@ -2,7 +2,7 @@ import {AnimationState, ITextureAnimationTarget} from '../../animation/Animation
 import {Matrix} from '@pixi/math';
 import {ColorTransform} from '../ColorTransform';
 import {Renderer, Texture, TextureMatrix} from '@pixi/core';
-import {Sprite} from '@pixi/Sprite';
+import {Sprite} from '@pixi/sprite';
 import {sign} from '@pixi/utils';
 
 const tempMat = new Matrix();


### PR DESCRIPTION
The import for @pixi/Sprite was capitalized, this does not cause any issues on windows, but on linux it does throw errors in my project, this pull request should fix that issue.